### PR TITLE
Refactor to remove all events from reducers. Also, extract all API ca…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -142,7 +142,7 @@
     },
     "acorn-jsx": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "requires": {
         "acorn": "^3.0.4"
@@ -150,7 +150,7 @@
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
-          "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
         }
       }
@@ -958,12 +958,12 @@
     },
     "babel-plugin-syntax-class-properties": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
       "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
     },
     "babel-plugin-syntax-dynamic-import": {
       "version": "6.18.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
       "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo="
     },
     "babel-plugin-syntax-exponentiation-operator": {
@@ -973,7 +973,7 @@
     },
     "babel-plugin-syntax-flow": {
       "version": "6.18.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
       "integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
     },
     "babel-plugin-syntax-jsx": {
@@ -983,7 +983,7 @@
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
     },
     "babel-plugin-syntax-trailing-function-commas": {
@@ -1729,7 +1729,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "requires": {
         "buffer-xor": "^1.0.3",
@@ -1770,7 +1770,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "requires": {
         "bn.js": "^4.1.0",
@@ -1818,7 +1818,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "requires": {
         "base64-js": "^1.0.2",
@@ -2410,7 +2410,7 @@
     },
     "color": {
       "version": "0.11.4",
-      "resolved": "http://registry.npmjs.org/color/-/color-0.11.4.tgz",
+      "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
       "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
       "requires": {
         "clone": "^1.0.2",
@@ -2619,7 +2619,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -2715,7 +2715,7 @@
     },
     "css-color-names": {
       "version": "0.0.4",
-      "resolved": "http://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
       "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA="
     },
     "css-loader": {
@@ -2815,7 +2815,7 @@
     },
     "cssnano": {
       "version": "3.10.0",
-      "resolved": "http://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
       "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
       "requires": {
         "autoprefixer": "^6.3.1",
@@ -3253,7 +3253,7 @@
     },
     "dotenv": {
       "version": "4.0.0",
-      "resolved": "http://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
       "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
     },
     "dotenv-expand": {
@@ -3263,7 +3263,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
     },
     "duplexer3": {
@@ -3700,7 +3700,7 @@
         },
         "load-json-file": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -3848,7 +3848,7 @@
     },
     "events": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
     },
     "eventsource": {
@@ -4056,7 +4056,7 @@
     },
     "external-editor": {
       "version": "2.2.0",
-      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "requires": {
         "chardet": "^0.4.0",
@@ -4206,7 +4206,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
@@ -4387,13 +4387,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4406,18 +4404,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4520,8 +4515,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4531,7 +4525,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4544,20 +4537,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4574,7 +4564,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4647,8 +4636,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4658,7 +4646,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4764,7 +4751,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4850,7 +4836,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "get-value": {
@@ -4946,7 +4932,7 @@
     },
     "got": {
       "version": "6.7.1",
-      "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "requires": {
         "create-error-class": "^3.0.0",
@@ -5239,7 +5225,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -5262,7 +5248,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
         "depd": "~1.1.2",
@@ -5526,7 +5512,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "requires": {
         "builtin-modules": "^1.0.0"
@@ -5648,7 +5634,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-path-cwd": {
@@ -6370,7 +6356,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -6672,7 +6658,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -7184,7 +7170,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "requires": {
         "lcid": "^1.0.0"
@@ -7432,7 +7418,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         }
       }
@@ -7466,7 +7452,7 @@
     },
     "postcss-calc": {
       "version": "5.3.1",
-      "resolved": "http://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
       "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
       "requires": {
         "postcss": "^5.0.2",
@@ -7588,7 +7574,7 @@
     },
     "postcss-discard-comments": {
       "version": "2.0.4",
-      "resolved": "http://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
       "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
       "requires": {
         "postcss": "^5.0.14"
@@ -7666,7 +7652,7 @@
     },
     "postcss-discard-empty": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
       "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
       "requires": {
         "postcss": "^5.0.14"
@@ -7705,7 +7691,7 @@
     },
     "postcss-discard-overridden": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
       "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
       "requires": {
         "postcss": "^5.0.16"
@@ -7744,7 +7730,7 @@
     },
     "postcss-discard-unused": {
       "version": "2.2.3",
-      "resolved": "http://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
       "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
       "requires": {
         "postcss": "^5.0.14",
@@ -7871,7 +7857,7 @@
     },
     "postcss-merge-idents": {
       "version": "2.1.7",
-      "resolved": "http://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
       "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
       "requires": {
         "has": "^1.0.1",
@@ -8008,7 +7994,7 @@
     },
     "postcss-minify-font-values": {
       "version": "1.0.5",
-      "resolved": "http://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
       "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
       "requires": {
         "object-assign": "^4.0.1",
@@ -8049,7 +8035,7 @@
     },
     "postcss-minify-gradients": {
       "version": "1.0.5",
-      "resolved": "http://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
       "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
       "requires": {
         "postcss": "^5.0.12",
@@ -8089,7 +8075,7 @@
     },
     "postcss-minify-params": {
       "version": "1.2.2",
-      "resolved": "http://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
       "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
       "requires": {
         "alphanum-sort": "^1.0.1",
@@ -8131,7 +8117,7 @@
     },
     "postcss-minify-selectors": {
       "version": "2.1.1",
-      "resolved": "http://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
       "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
       "requires": {
         "alphanum-sort": "^1.0.2",
@@ -8208,7 +8194,7 @@
     },
     "postcss-normalize-charset": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
       "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
       "requires": {
         "postcss": "^5.0.5"
@@ -8247,7 +8233,7 @@
     },
     "postcss-normalize-url": {
       "version": "3.0.8",
-      "resolved": "http://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
       "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
       "requires": {
         "is-absolute-url": "^2.0.0",
@@ -8329,7 +8315,7 @@
     },
     "postcss-reduce-idents": {
       "version": "2.4.0",
-      "resolved": "http://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
       "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
       "requires": {
         "postcss": "^5.0.4",
@@ -8369,7 +8355,7 @@
     },
     "postcss-reduce-initial": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
       "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
       "requires": {
         "postcss": "^5.0.4"
@@ -8408,7 +8394,7 @@
     },
     "postcss-reduce-transforms": {
       "version": "1.0.4",
-      "resolved": "http://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
       "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
       "requires": {
         "has": "^1.0.1",
@@ -8459,7 +8445,7 @@
     },
     "postcss-svgo": {
       "version": "2.1.6",
-      "resolved": "http://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
       "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
       "requires": {
         "is-svg": "^2.0.0",
@@ -8501,7 +8487,7 @@
     },
     "postcss-unique-selectors": {
       "version": "2.0.2",
-      "resolved": "http://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
       "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
       "requires": {
         "alphanum-sort": "^1.0.1",
@@ -8547,7 +8533,7 @@
     },
     "postcss-zindex": {
       "version": "2.2.0",
-      "resolved": "http://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
       "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
       "requires": {
         "has": "^1.0.1",
@@ -8809,7 +8795,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -9125,7 +9111,7 @@
     },
     "reduce-css-calc": {
       "version": "1.3.0",
-      "resolved": "http://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
       "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
       "requires": {
         "balanced-match": "^0.4.2",
@@ -9555,7 +9541,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -9704,7 +9690,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
         "inherits": "^2.0.1",
@@ -10258,7 +10244,7 @@
     },
     "table": {
       "version": "4.0.3",
-      "resolved": "http://registry.npmjs.org/table/-/table-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
       "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "requires": {
         "ajv": "^6.0.1",
@@ -10339,7 +10325,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "thunky": {
@@ -10575,7 +10561,7 @@
         },
         "yargs": {
           "version": "3.10.0",
-          "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "requires": {
             "camelcase": "^1.0.2",
@@ -10967,7 +10953,7 @@
         },
         "load-json-file": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -11182,7 +11168,7 @@
         },
         "yargs": {
           "version": "6.6.0",
-          "resolved": "http://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
           "requires": {
             "camelcase": "^3.0.0",
@@ -11202,7 +11188,7 @@
         },
         "yargs-parser": {
           "version": "4.2.1",
-          "resolved": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
           "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
           "requires": {
             "camelcase": "^3.0.0"
@@ -11233,7 +11219,7 @@
         },
         "jsonfile": {
           "version": "2.4.0",
-          "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
           "requires": {
             "graceful-fs": "^4.1.6"
@@ -11349,7 +11335,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",

--- a/src/action-creators/DmScreenActionCreators.js
+++ b/src/action-creators/DmScreenActionCreators.js
@@ -1,0 +1,13 @@
+import { addDmScreenResult, addCustomButton, toggleForm } from '../actions/DmScreenActions'
+
+export const dmScreenAddResultAction = (result) => (dispatch, getState) => {
+    dispatch(addDmScreenResult(result));
+}
+
+export const addCustomButtonAction = (button) => (dispatch) => {
+    dispatch(addCustomButton(button))
+}
+
+export const toggleFormAction = (showForm) => (dispatch) => {
+    dispatch(toggleForm(showForm))
+}

--- a/src/action-creators/index.js
+++ b/src/action-creators/index.js
@@ -2,40 +2,10 @@ import React from 'react'
 import Keys from '../models/Keys'
 //import Monsters from '../models/AllMonsters'
 import { showMonster, selectMonsterOption, showS3SelectResult, 
-    showS3SelectDMScreenResult, addDmScreenResult, addCustomButton, 
-    toggleForm, display35Monster } from '../actions'
-
+    showS3SelectDMScreenResult, display35Monster } from '../actions'
+import MonstersApi from '../apiClients/MonsterApi'
 import rollTimeString from '../utils/ResultTimestamp'
-
-//TODO: Remove this if it is not used...
-export const fetchMonsterAction = (monsterName) => (dispatch, getState) => {
-    fetchMonster(monsterName, dispatch);
-}
-
-const fetchMonster = (monsterName, dispatch, source) => {
-    if (!monsterName) return;
-    console.log("ABOUT TO GET: " + monsterName);
-    let monsterKey = monsterName.toLowerCase()
-        .replace(new RegExp("[,()']", 'g'), "")
-        .replace(new RegExp(" ", 'g'), "_");
-
-    // const baseKey = monsterKey.substring(0, nthIndexOf(monsterKey, "_", 3));
-    // const baseMonster = (monsterKey.startsWith("dragon_")) ? Monsters[baseKey] : undefined;
-    // const monster = Monsters[monsterKey];
-
-    // if (baseMonster) {
-    //     const mergedMonster = {
-    //         ...baseMonster,
-    //         ...monster
-    //     }
-    //     return dispatch(showMonster(mergedMonster));
-    // }
-    // return dispatch(showMonster(monster));
-    return fetch(`https://api.cleverorc.com/monsters/${monsterKey}`)
-        .then(resp => resp.json())
-        .then(data =>  dispatch(showMonster(data, source)))
-        .catch(err => console.log(err));
-}
+import ReactGA from 'react-ga';
 
 export const fetchMonsterAdvancer35v2 = (monsterName, fields) => (dispatch) => {
     const baseUri = `https://monsteradvancerv2.mircloud.us/api/monster/${monsterName}`
@@ -63,8 +33,15 @@ export const monsterSelectChangeHandler = (e) => (dispatch, getState) => {
     
     const monsterName = (e && e.value) ? e.value : e.label;
     dispatch(selectMonsterOption(monsterName));
-    const source = "Monster Find"
-    fetchMonster(monsterName, dispatch, source);
+    MonstersApi.getMonsterByName(monsterName)
+        .then(data => {
+            ReactGA.event({
+                category: "Monster Find",
+                action: monsterName
+            });
+            return data;
+        })
+        .then(data =>  dispatch(showMonster(data)))
 }
 
 export const keyPressHandler = (e) => {
@@ -72,7 +49,12 @@ export const keyPressHandler = (e) => {
         switch(e.which) {
             case Keys.LEFT:
             console.log("LEFT KEY PRESSED");
-            fetchMonster("behir", dispatch);
+            var promise = MonstersApi.getMonsterByName("behir");
+            ReactGA.event({
+                category: "Monster Secret Key Press",
+                action: "behir"
+            });
+            promise.then(data =>  dispatch(showMonster(data)))
             break;
     
             case Keys.UP:
@@ -96,7 +78,6 @@ export const keyPressHandler = (e) => {
     }
 };
 
-
 //using for DMScreen right now
 export const fetchSelectAction = (searchParams) => (dispatch, getState) => {
     const chooseMonster = (monsters, searchParamsAsHtmlParams) => {
@@ -109,9 +90,16 @@ export const fetchSelectAction = (searchParams) => (dispatch, getState) => {
         }
         console.log("Select Multiple Monsters", monsters, numOfMonsters, selectedMonsters);
         const monsterButtons = selectedMonsters.map(x => {
-            const source = "DM Screen"
             const lookupMonster = () => {
-                fetchMonster(x, dispatch, source);
+                var promise = MonstersApi.getMonsterByName(x);
+                promise.then(data => {
+                    ReactGA.event({
+                        category: "DM Screen",
+                        action: x
+                    })
+                    return data;
+                });
+                promise.then(data =>  dispatch(showMonster(data)));
             }
             return <button type="button" onClick={lookupMonster} className="purpleAwesome">{x}</button>
         })
@@ -122,65 +110,30 @@ export const fetchSelectAction = (searchParams) => (dispatch, getState) => {
         const result = [<span>{desc}</span>, ...monsterButtons]
         return showS3SelectDMScreenResult(result, searchParamsAsHtmlParams);
     }
-    fetchSelect(searchParams, dispatch, chooseMonster);
+    var resultsPromise = MonstersApi.getMonstersByCriteria(searchParams);
+    resultsPromise.then(monsters => {
+        if (monsters && monsters.length > 0) {
+            var searchFieldsAsHtmlParams = MonstersApi.convertCriteriaToHtmlParameters(searchParams);
+            ReactGA.event({
+                category: 'Monster Search',
+                action: searchFieldsAsHtmlParams
+            });
+            dispatch(chooseMonster(monsters, searchFieldsAsHtmlParams));
+        }    
+    });
 }
 
 export const monsterS3SelectChangeHandler = (values) => (dispatch, getState) => {
     console.warn('Search via S3 select');
-    fetchSelect(values, dispatch);
-} 
-
-const fetchSelect = (searchParams, dispatch, action = showS3SelectResult) => {
-    console.log("ABOUT TO SEARCH ON", searchParams);
-
-    let searchFields = [];
-    if (searchParams.cr) {
-        const through = (searchParams.crOperator === 'btw') ? "-" + searchParams.crEnd : "";
-        searchFields.push(`cr=${encodeURI(searchParams.crOperator)}${searchParams.cr}${through}`);
-    }
-    if (searchParams.str) {
-        const through = (searchParams.strOperator === 'btw') ? "-" + searchParams.strEnd : "";
-        searchFields.push(`str=${encodeURI(searchParams.strOperator)}${searchParams.str}${through}`);
-    }
-    if (searchParams.dex) {
-        const through = (searchParams.dexOperator === 'btw') ? "-" + searchParams.dexEnd : "";
-        searchFields.push(`dex=${encodeURI(searchParams.dexOperator)}${searchParams.dex}${through}`);
-    }
-    if (searchParams.ac) {
-        const through = (searchParams.acOperator === 'btw') ? "-" + searchParams.acEnd : "";
-        searchFields.push(`ac=${encodeURI(searchParams.acOperator)}${searchParams.ac}${through}`);
-    }
-    if (searchParams.environment) {
-        searchFields.push(`environment=${searchParams.environmentOperator}${searchParams.environment}`)
-    }
-    
-    const searchFieldsAsHtmlParams = searchFields.join("&");
-
-    //https://monstersearchapi.cleverorc.com/?
-    const baseUri = 'https://99hy8krr49.execute-api.us-west-2.amazonaws.com/prod';
-    const url = `${baseUri}?${searchFieldsAsHtmlParams}`;
-    console.log("URL TO FETCH: ", url);
-    const results = fetch(url)
-        .then(resp => resp.json())
-        .then(json => {
-            console.log("REAL RESPONSE FROM S3 Select URL");
-            console.log(json);
-            return json.results
-        });
-    return results.then(monsters => {
-        if (monsters && monsters.length > 0)
-            dispatch(action(monsters, searchFieldsAsHtmlParams));
+    var resultsPromise = MonstersApi.getMonstersByCriteria(values);
+    resultsPromise.then(monsters => {
+        if (monsters && monsters.length > 0) {
+            var searchFieldsAsHtmlParams = MonstersApi.convertCriteriaToHtmlParameters(values);
+            ReactGA.event({
+                category: 'Monster Search',
+                action: searchFieldsAsHtmlParams
+            });
+            dispatch(showS3SelectResult(monsters, searchFieldsAsHtmlParams));
+        }
     });
-}
-
-export const dmScreenAddResultAction = (result) => (dispatch, getState) => {
-    dispatch(addDmScreenResult(result));
-}
-
-export const addCustomButtonAction = (button) => (dispatch) => {
-    dispatch(addCustomButton(button))
-}
-
-export const toggleFormAction = (showForm) => (dispatch) => {
-    dispatch(toggleForm(showForm))
-}
+} 

--- a/src/actions/DmScreenActions.js
+++ b/src/actions/DmScreenActions.js
@@ -1,0 +1,18 @@
+export const ADD_RESULT = 'ADD_RESULT'
+export const ADD_CUSTOM_BUTTON = 'ADD_CUSTOM_BUTTON'
+export const TOGGLE_FORM = 'TOGGLE_FORM'
+
+export const addDmScreenResult = (result) => ({
+    type: 'ADD_RESULT',
+    result: result
+});
+
+export const addCustomButton = (button) => ({
+    type: 'ADD_CUSTOM_BUTTON',
+    button: button
+});
+
+export const toggleForm = (showForm) => ({
+    type: 'TOGGLE_FORM',
+    showForm: showForm
+});

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -2,14 +2,10 @@ export const SHOW_MONSTER = 'SHOW_MONSTER'
 export const SELECT_MONSTER = 'SELECT_MONSTER'
 export const S3_SELECT_SHOW = 'S3_SELECT_SHOW'
 export const S3_SELECT_DMSCREEN_SHOW = 'S3_SELECT_DMSCREEN_SHOW'
-export const ADD_RESULT = 'ADD_RESULT'
-export const ADD_CUSTOM_BUTTON = 'ADD_CUSTOM_BUTTON'
-export const TOGGLE_FORM = 'TOGGLE_FORM'
 
-export const showMonster = (monsterJson, source) => ({
+export const showMonster = (monsterJson) => ({
     type: 'SHOW_MONSTER',
-    monster: monsterJson,
-    source: source
+    monster: monsterJson
 });
 
 export const showS3SelectResult = (monsterListJson, searchParams) => ({
@@ -27,21 +23,6 @@ export const showS3SelectDMScreenResult = (monsterListJson, searchParams) => ({
 export const selectMonsterOption = (selectedMonsterName) => ({
     type: 'SELECT_MONSTER',
     name: selectedMonsterName
-});
-
-export const addDmScreenResult = (result) => ({
-    type: 'ADD_RESULT',
-    result: result
-});
-
-export const addCustomButton = (button) => ({
-    type: 'ADD_CUSTOM_BUTTON',
-    button: button
-});
-
-export const toggleForm = (showForm) => ({
-    type: 'TOGGLE_FORM',
-    showForm: showForm
 });
 
 /* Monster Advancer 3.5 v2 Actions */

--- a/src/apiClients/MonsterApi.js
+++ b/src/apiClients/MonsterApi.js
@@ -1,0 +1,91 @@
+export const convertCriteriaToHtmlParameters = (criteria) => {
+    var searchParams = criteria;
+    let searchFields = [];
+    if (searchParams.cr) {
+        const through = (searchParams.crOperator === 'btw') ? "-" + searchParams.crEnd : "";
+        searchFields.push(`cr=${encodeURI(searchParams.crOperator)}${searchParams.cr}${through}`);
+    }
+    if (searchParams.str) {
+        const through = (searchParams.strOperator === 'btw') ? "-" + searchParams.strEnd : "";
+        searchFields.push(`str=${encodeURI(searchParams.strOperator)}${searchParams.str}${through}`);
+    }
+    if (searchParams.dex) {
+        const through = (searchParams.dexOperator === 'btw') ? "-" + searchParams.dexEnd : "";
+        searchFields.push(`dex=${encodeURI(searchParams.dexOperator)}${searchParams.dex}${through}`);
+    }
+    if (searchParams.ac) {
+        const through = (searchParams.acOperator === 'btw') ? "-" + searchParams.acEnd : "";
+        searchFields.push(`ac=${encodeURI(searchParams.acOperator)}${searchParams.ac}${through}`);
+    }
+    if (searchParams.environment) {
+        searchFields.push(`environment=${searchParams.environmentOperator}${searchParams.environment}`)
+    }
+    
+    return searchFields.join("&");
+}
+
+export const getMonstersByCriteria = (criteria) => {
+    console.log("ABOUT TO SEARCH ON", criteria);
+
+    const searchFieldsAsHtmlParams = convertCriteriaToHtmlParameters(criteria);
+
+    //https://monstersearchapi.cleverorc.com/?
+    const baseUri = 'https://99hy8krr49.execute-api.us-west-2.amazonaws.com/prod';
+    const url = `${baseUri}?${searchFieldsAsHtmlParams}`;
+    console.log("URL TO FETCH: ", url);
+    const resultsPromise = fetch(url)
+        .then(resp => resp.json())
+        .then(json => {
+            console.log("REAL RESPONSE FROM S3 Select URL");
+            console.log(json);
+            return json.results
+        });
+    return resultsPromise;
+}
+
+export const getMonsterByName = (monsterName) => {
+    if (!monsterName) return;
+    console.log("ABOUT TO GET: " + monsterName);
+    let monsterKey = monsterName.toLowerCase()
+        .replace(new RegExp("[,()']", 'g'), "")
+        .replace(new RegExp(" ", 'g'), "_");
+
+    // const baseKey = monsterKey.substring(0, nthIndexOf(monsterKey, "_", 3));
+    // const baseMonster = (monsterKey.startsWith("dragon_")) ? Monsters[baseKey] : undefined;
+    // const monster = Monsters[monsterKey];
+
+    // if (baseMonster) {
+    //     const mergedMonster = {
+    //         ...baseMonster,
+    //         ...monster
+    //     }
+    //     return dispatch(showMonster(mergedMonster));
+    // }
+    // return dispatch(showMonster(monster));
+    return fetch(`https://api.cleverorc.com/monsters/${monsterKey}`)
+        .then(resp => resp.json())
+        .catch(err => console.log(err));
+}
+
+export const getMonsterWithCustomizations = (monsterName, fields) => {
+    const baseUri = `https://monsteradvancerv2.mircloud.us/api/monster/${monsterName}`
+    let fieldsAsHtmlParams = [];
+    for (var i = 0;i<fields.length; i++) {
+        const field = fields[i];
+        if (!field.isMulti)
+            fieldsAsHtmlParams.push(field.name + "=" + field.value);
+        else
+            fieldsAsHtmlParams.push(field.name + "=" + field.value.join(","));
+    }
+    const uriParams = (fieldsAsHtmlParams.length > 0) ? fieldsAsHtmlParams.join("&") : "";
+    return fetch(`${baseUri}?${uriParams}`)
+        .then(resp => resp.json())
+        .then(data => {console.log(data); return data;})
+        .catch(err => console.log(err));
+}
+
+export default { 
+    getMonstersByCriteria: getMonstersByCriteria, 
+    convertCriteriaToHtmlParameters: convertCriteriaToHtmlParameters,
+    getMonsterByName: getMonsterByName 
+};

--- a/src/components/DMScreen/DMScreen.js
+++ b/src/components/DMScreen/DMScreen.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux'
-import {dmScreenAddResultAction, addCustomButtonAction, toggleFormAction, fetchSelectAction} from '../../action-creators'
+import {fetchSelectAction} from '../../action-creators'
+import {dmScreenAddResultAction, addCustomButtonAction, toggleFormAction} from '../../action-creators/DmScreenActionCreators'
 import DiceBag from '../../utils/DiceBag'
 import CreateAButtonForm from '../../components/DMScreen/CreateAButtonForm'
 import rollTimeString from '../../utils/ResultTimestamp'

--- a/src/reducers/DMScreenReducer.js
+++ b/src/reducers/DMScreenReducer.js
@@ -1,0 +1,50 @@
+import React from 'react'
+import * as DmScreenActions from '../actions/DmScreenActions'
+import * as Actions from '../actions'
+import MonsterDisplay from '../components/MonsterDisplay'
+import ReactGA from 'react-ga';
+
+const dmScreen = (state = {results:[], buttons:[], showForm: false}, action) => {
+    const category = "DM Screen";
+    switch (action.type) {
+      case DmScreenActions.ADD_RESULT:
+        return {
+          ...state,
+          results: state.results.concat(action.result)
+        };
+      case DmScreenActions.ADD_CUSTOM_BUTTON:
+        return {
+          ...state,
+          buttons: state.buttons.concat(action.button)
+        };
+      case DmScreenActions.TOGGLE_FORM:
+        return {
+          ...state,
+          showForm: action.showForm
+        };
+      case Actions.S3_SELECT_DMSCREEN_SHOW:
+        ReactGA.event({
+          category: category,
+          action: action.searchParams
+        })
+        return {
+          ...state,
+          results: [...state.results, action.monsterList]
+        }
+      case Actions.SHOW_MONSTER:
+        if (action.source === category) {
+          ReactGA.event({
+            category: category,
+            action: action.monster.name
+          })
+        }
+        return {
+          ...state,
+          results: [...state.results, <MonsterDisplay monster={{statBlock: action.monster}}/>]
+        }
+      default:
+        return state;
+    }
+  }
+
+  export default dmScreen;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,14 +1,8 @@
-import React from 'react'
 import { combineReducers } from 'redux'
 import { reducer as formReducer } from 'redux-form'
-
 import * as Actions from '../actions'
-
 import Aasimar from '../models/Aasimar'
-
-import MonsterDisplay from '../components/MonsterDisplay'
-
-import ReactGA from 'react-ga';
+import dmScreen from './DMScreenReducer'
 
 const config = (state = { initialState: "basicConfig"}, action) => {
   switch (action.type) {
@@ -30,18 +24,8 @@ const select = (state = { selectedMonsterName: Aasimar.name}, action) => {
 }
 
 const monster = (state = { statBlock: Aasimar}, action) => {
-  //console.log("LAYOUT REDUCER");
-  const category = "Monster Find";
   switch (action.type) {
     case Actions.SHOW_MONSTER: 
-      //console.log("SHOW MONSTER");
-      //console.log(action.monster);
-      if (action.source === category) {
-        ReactGA.event({
-          category: category,
-          action: action.monster.name
-        })
-      }
       return {
         ...state,
         statBlock: action.monster
@@ -54,12 +38,6 @@ const monster = (state = { statBlock: Aasimar}, action) => {
 const s3Select = (state = { monsterList:[]}, action) => {
   switch (action.type) {
     case Actions.S3_SELECT_SHOW: 
-      //console.log("SHOW MONSTER");
-      //console.log(action.monster);
-      ReactGA.event({
-        category: 'Monster Search',
-        action: action.searchParams
-      })
       return {
         ...state,
         monsterList: action.monsterList
@@ -76,49 +54,6 @@ const monsterAdvancer = (state = { monster:{} }, action) => {
         ...state,
         monster: action.monster
       };
-    default:
-      return state;
-  }
-}
-
-const dmScreen = (state = {results:[], buttons:[], showForm: false}, action) => {
-  const category = "DM Screen";
-  switch (action.type) {
-    case Actions.ADD_RESULT:
-      return {
-        ...state,
-        results: state.results.concat(action.result)
-      };
-    case Actions.ADD_CUSTOM_BUTTON:
-      return {
-        ...state,
-        buttons: state.buttons.concat(action.button)
-      };
-    case Actions.TOGGLE_FORM:
-      return {
-        ...state,
-        showForm: action.showForm
-      };
-    case Actions.S3_SELECT_DMSCREEN_SHOW:
-      ReactGA.event({
-        category: category,
-        action: action.searchParams
-      })
-      return {
-        ...state,
-        results: [...state.results, action.monsterList]
-      }
-    case Actions.SHOW_MONSTER:
-      if (action.source === category) {
-        ReactGA.event({
-          category: category,
-          action: action.monster.name
-        })
-      }
-      return {
-        ...state,
-        results: [...state.results, <MonsterDisplay monster={{statBlock: action.monster}}/>]
-      }
     default:
       return state;
   }


### PR DESCRIPTION
Too many things are tangled up. We need to untangle the dependencies by better promise use. This should also help us remove google analytics events from reducers since we'll move that into the promise chains of all the API calls. All the API calls will be put into a client file MonstersAPI (even though it hits 3 different uris for now having them all in one file makes sense)