### PR TITLE
Fix bug where main dragon entry doesn't display because of missing data

### DIFF
--- a/src/components/PathfinderMonsterAdvancer/AdvancementTools/ChallengeRatingCalculator.js
+++ b/src/components/PathfinderMonsterAdvancer/AdvancementTools/ChallengeRatingCalculator.js
@@ -52,6 +52,7 @@ export const calculateAcCr = (ac) => {
 }
 
 export const calculateAttackCr = (attacks) => {
+    if (!attacks) return 0;
     const firstAttackBonusOfMainAttack = parseInt(attacks[0][0].attackBonus);
     return calculateStatCr('highAttack', firstAttackBonusOfMainAttack);
 }
@@ -80,6 +81,7 @@ export const calculateDamageFromAttackSequence = (attackSequence) => {
 }
 
 export const calculateDamageCr = (attacks) => {
+    if (!attacks) return 0;
     console.log("input to dmg cr calc", attacks);
     const firstAttack = attacks[0];
     //calculate the dmg from each part of that attack.

--- a/src/components/PathfinderMonsterAdvancer/AdvancementUtils.js
+++ b/src/components/PathfinderMonsterAdvancer/AdvancementUtils.js
@@ -102,6 +102,10 @@ export const IsWillSaveGood = (creatureTypeInfo) => {
 }
 
 export const getCreatureTypeInfo = (creatureType) => {
+    if (!creatureType) {
+        console.warn("Creature type was not found. Returning Dragon Type as default.");
+        return creatureStatsByType.find(x => x.creature_type === 'Dragon');
+    }
     return creatureStatsByType.find(x => x.creature_type.toLowerCase() === creatureType.toLowerCase());
 }
 


### PR DESCRIPTION
There is still a larger bug where these partial dragon entries exist that really need merged with the normal entries to ensure all data is in the normal entries. This fix is just to prevent client errors for now.